### PR TITLE
add ability to use nbt in icon

### DIFF
--- a/src/main/java/com/mrcrayfish/catalogue/client/screen/CatalogueModListScreen.java
+++ b/src/main/java/com/mrcrayfish/catalogue/client/screen/CatalogueModListScreen.java
@@ -759,12 +759,14 @@ public class CatalogueModListScreen extends Screen
 
             if(!itemIcon.isEmpty())
             {
-                try {
+                try
+                {
                     ItemParser parser = new ItemParser(new StringReader(itemIcon), false).parse();
                     ItemStack item = new ItemStack(parser.getItem(), 1, parser.getNbt());
                     ITEM_CACHE.put(this.info.getModId(), item);
                     return item;
-                } catch (CommandSyntaxException ignored) {}
+                }
+                catch (CommandSyntaxException ignored) {}
             }
 
             // If the mod doesn't specify an item to use, Catalogue will attempt to get an item from the mod


### PR DESCRIPTION
This PR adds the ability to use nbt with the command syntax in the `itemIcon`/`catalogueImageIcon` field