### PR TITLE
MC1.16.x Catalogue Simplified Chinese Translation

### DIFF
--- a/src/main/resources/assets/catalogue/lang/zh_cn.json
+++ b/src/main/resources/assets/catalogue/lang/zh_cn.json
@@ -1,0 +1,5 @@
+{
+    "fml.menu.mods.filter_updates": "只显示有更新的模组",
+    "catalogue.gui.no_selection": "没有选择模组...",
+    "catalogue.gui.info": "此菜单由 Catalogue 重新设计。单击此处打开此模组的 CurseForge 页面！"
+}


### PR DESCRIPTION
这是MC1.16.x版本Catalogue的简体中文翻译。
This is a Simplified Chinese translation of MC1.16.x Catalogue.