### PR TITLE
Bump versions

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.0-SNAPSHOT'
+    id 'fabric-loom' version '1.5-SNAPSHOT'
     id 'maven-publish'
     id 'idea'
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java'
     id 'eclipse'
     id 'maven-publish'
-    id 'net.minecraftforge.gradle' version '5.1.+'
+    id 'net.minecraftforge.gradle' version '[6.0, 6.2)'
 }
 
 archivesBaseName = "${mod_id}-forge"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Recently I tried to include Catalogue as subproject but since I used gradle 8.6, it was not compatible with Forge Gradle 5.1 that catalogue uses.
Since it's often better to use more recent version, I've bumped version of gradle, forge gradle, and fabric loom.
I have tested it by running `./gradlew build` and it worked well.